### PR TITLE
Add sql file to add testing env db upon docker componse

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - database:/var/lib/postgresql/data
-      - ./initdb:/docker-entrypoint-initdb.d
+      - ./docker_postgres_init.sql:/docker-entrypoint-initdb.d/docker_postgres_init.sql
 volumes:
   database:
     driver: local

--- a/docker_postgres_init.sql
+++ b/docker_postgres_init.sql
@@ -1,0 +1,23 @@
+-- Check for user first to avoid initialization failure from second time
+DO
+$do$
+BEGIN
+   IF EXISTS (
+      SELECT FROM pg_catalog.pg_roles
+      WHERE  rolname = 'test') THEN
+
+      RAISE NOTICE 'Role "test" already exists. Skipping user creation.';
+   ELSE
+    CREATE USER test WITH PASSWORD 'test' CREATEDB;
+   END IF;
+END
+$do$;
+
+CREATE DATABASE "trello-clone-test"
+    WITH 
+    OWNER = test
+    ENCODING = 'UTF8'
+    LC_COLLATE = 'en_US.utf8'
+    LC_CTYPE = 'en_US.utf8'
+    TABLESPACE = pg_default
+    CONNECTION LIMIT = -1;

--- a/tests/helper/index.ts
+++ b/tests/helper/index.ts
@@ -13,9 +13,9 @@ export function build(): FastifyInstance {
 
   // Set up DB with mocked environment valuables.
   beforeAll(async () => {
-    process.env.POSTGRES_USER = "root";
-    process.env.POSTGRES_PASSWORD = "root";
-    process.env.POSTGRES_DB = "trello-clone";
+    process.env.POSTGRES_USER = "test";
+    process.env.POSTGRES_PASSWORD = "test";
+    process.env.POSTGRES_DB = "trello-clone-test";
 
     await initializeDatabase();
   });


### PR DESCRIPTION
### ticket:
https://github.com/ryonryon/trello-clone/issues/34

### changes:
- Add sql file to add test database additionally
- Tweak db connection env for test to make it connect to testing db
- Modify docker-compose file to execute SQL file

An article that I followed:
https://onexlab-io.medium.com/docker-compose-postgres-multiple-database-bbc0816db603

Not so sure if it's the best practice, but I got it working anyway. It's pretty ugly even from my perspective because it's the very first experience for me to set up db environment. So plz lemme know if you can give me some advice to improve it😄  

### Heads up
Since we don't have a creation endpoint yet, you will need to manually fill in some data to run tests. So once you successfully run `docker compose up -d` on your local, plz fill in "initial" data so that you'll be able to run tests against test db. I'll leave the query I used to reduce the pain of writing them.

```
INSERT INTO tickets (name, description, sort, project_id, column_id)
        VALUES ('This is the first ticket', 'Yay this is the first one', 1, 1, 1);

INSERT INTO projects (name, description)
        VALUES ('First Project','This is the first column');

INSERT INTO columns (name, sort, project_id)
        VALUES ('This is the first column', 1, 1);
```