### PR TITLE
Fix broken test environment with test cases fix 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "nodemon src/index.ts",
     "test": "jest",
+    "test-warnings": "jest --detectOpenHandles",
     "test:watch": "jest --watch",
     "lint": "eslint src/**/*.ts",
     "format": "eslint src/**/*.ts --fix"

--- a/src/controllers/__tests__/project.test.ts
+++ b/src/controllers/__tests__/project.test.ts
@@ -16,13 +16,27 @@ describe("get project", () => {
   });
 
   test("Passed appropriate query - it should successfully fetch existing project", async () => {
+    // Since mockProject doesn't align to response of the endpoint
+    // This variable is to set the same shape as the response body
+    const expectedReturn = {
+      id: mockProject.id,
+      name: mockProject.name,
+      description: mockProject.description,
+      columns: [
+        { ...mockProject.columns[0], tickets: [] },
+        { ...mockProject.columns[1], tickets: [] },
+      ],
+    };
+
+    // act
     const res = await app.inject({
       method: "get",
       url: `/projects/${mockProject.id}`,
       payload: {},
     });
 
-    expect(res).toBe(mockProject);
+    // assign
+    expect(JSON.parse(res.body)).toEqual(expectedReturn);
   });
 
   test("Passed id that DOES NOT exist - it should successfully fetch existing project", async () => {

--- a/src/controllers/__tests__/ticket.test.ts
+++ b/src/controllers/__tests__/ticket.test.ts
@@ -1,6 +1,6 @@
 import { build } from "../../../tests/helper";
-import { createTestTicket } from "../../../tests/helper/utils";
-import { Ticket } from "../../entities";
+import { createTestProject } from "../../../tests/helper/utils";
+import { Project } from "../../entities";
 
 const app = build();
 
@@ -106,21 +106,25 @@ describe("createTicket", () => {
 });
 
 describe("editTicket", () => {
-  let mockTicket: Ticket;
+  let mockedProject: Project;
 
   beforeAll(async () => {
-    mockTicket = await createTestTicket();
+    mockedProject = await createTestProject();
   });
 
   afterAll(async () => {
-    await mockTicket.remove();
+    await mockedProject.remove();
   });
 
   test("Passed appropriate body and query - it should successfully edit existing ticket", async () => {
     const mockName = "this is mocked name";
+    const mockedProjectId = mockedProject.id;
+    const mockedColumnId = mockedProject.columns[0].id;
+    const mockedTicketId = mockedProject.tickets[0].id;
+
     const res = await app.inject({
       method: "put",
-      url: "/tickets/1",
+      url: `/projects/${mockedProjectId}/columns/${mockedColumnId}/tickets/${mockedTicketId}`,
       payload: {
         name: mockName,
       },
@@ -134,9 +138,12 @@ describe("editTicket", () => {
     const expectedErrorMessage =
       '{"statusCode":500,"error":"Internal Server Error","message":"Invalid ticket id: NaN"}';
     const mockName = "test";
+    const mockedProjectId = mockedProject.id;
+    const mockedColumnId = mockedProject.columns[0].id;
+
     const res = await app.inject({
       method: "put",
-      url: "/tickets/a",
+      url: `/projects/${mockedProjectId}/columns/${mockedColumnId}/tickets/a`,
       payload: {
         name: mockName,
       },
@@ -150,9 +157,13 @@ describe("editTicket", () => {
     const expectedErrorMessage =
       '{"statusCode":500,"error":"Internal Server Error","message":"Could not update the ticket with the request body: {\\"crazyKey\\":212}"}';
     const mockName = 212;
+    const mockedProjectId = mockedProject.id;
+    const mockedColumnId = mockedProject.columns[0].id;
+    const mockedTicketId = mockedProject.tickets[0].id;
+
     const res = await app.inject({
       method: "put",
-      url: `/tickets/${mockTicket.id}`,
+      url: `/projects/${mockedProjectId}/columns/${mockedColumnId}/tickets/${mockedTicketId}`,
       payload: {
         crazyKey: mockName,
       },

--- a/src/database/createConnection.ts
+++ b/src/database/createConnection.ts
@@ -2,7 +2,11 @@ import { DataSource } from "typeorm";
 
 import * as entities from "../entities";
 
-export default async (): Promise<DataSource> => {
+/**
+ * Returns an instance of DataSource object which contains
+ * functions to establish/destroy connection between server and the DB
+ */
+export default (): DataSource => {
   const dataSource = new DataSource({
     type: "postgres",
     host: "localhost",
@@ -14,5 +18,5 @@ export default async (): Promise<DataSource> => {
     synchronize: true,
   });
 
-  return await dataSource.initialize();
+  return dataSource;
 };

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,11 +1,19 @@
-import createConnection from "./createConnection";
+import getDataSource from "./createConnection";
 
 const initializeDatabase = async (): Promise<void> => {
   try {
-    await createConnection();
+    await getDataSource().initialize();
   } catch (error) {
     console.log(error);
   }
 };
 
-export { initializeDatabase };
+const destroyDatabaseConnection = async (): Promise<void> => {
+  try {
+    await getDataSource().destroy();
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export { initializeDatabase, destroyDatabaseConnection };

--- a/tests/helper/index.ts
+++ b/tests/helper/index.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from "fastify";
-import { initializeDatabase } from "../../src/database";
+import { DataSource } from "typeorm";
+import dataSource from "../../src/database/createConnection";
 import { initializeServer } from "../../src/server";
 
 /**
@@ -10,6 +11,7 @@ export function build(): FastifyInstance {
   // Set up server. This instance will be the return
   // for jest to access and manipulate its APIs
   const app = initializeServer();
+  let database: DataSource;
 
   // Set up DB with mocked environment valuables.
   beforeAll(async () => {
@@ -17,10 +19,13 @@ export function build(): FastifyInstance {
     process.env.POSTGRES_PASSWORD = "test";
     process.env.POSTGRES_DB = "trello-clone-test";
 
-    await initializeDatabase();
+    database = dataSource();
+    await database.initialize();
   });
 
+  // Clean up both server and database
   afterAll(async () => {
+    await database.destroy();
     await app.close();
   });
 


### PR DESCRIPTION
### description
This is a PR to fix the broken testing environment and its failing cases.

**The issue of the previous environment** - We didn't kill the connection of DB at the end of the test so eventually just got too occupied by connections while it's running parallel tests. Apparently, jest only can hold 4 async tests at the same time, so eventually, our `build()` function didn't destroy DB connection so it remains held by jest's worker and exceeds its limit.

**Fix** - It was fairly simple to fix. All I needed to do was just to segregate `DataSource` object from connection initialization logic to access the instance itself from test, so that we could call a function `destroy` to close it off so jest can safely finish its job.

### If your problem persists
If you still have the following error;
```
Invalid return value:
      process() or/and processAsync() method of code transformer found at...
```
It's likely because of your local jest's version mismatch. Try remove `node_modules` and install packages again. If it still didn't help, remove `package.json` file with `node_modules`and try again.

<img width="1311" alt="Screen Shot 2022-05-09 at 11 23 26 PM" src="https://user-images.githubusercontent.com/44686790/167562304-24a38e0f-7a87-4256-b7d8-80203dfad5f0.png">
