### PR TITLE
Extract `listen()` from server function not to run it in unit tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,16 @@ import "dotenv/config";
 const initializeApp = async (): Promise<void> => {
   await initializeDatabase();
 
-  initializeServer();
+  const server = initializeServer();
+
+  server.listen(5030, (err, address) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+
+    console.log(`Server listening at ${address}`);
+  });
 };
 
 initializeApp();

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,16 +23,6 @@ const initializeServer = () => {
   server.delete("/projects/:projectId/columns/:columnId/tickets/:ticketId", ticket.deleteTicket);
   server.put("/projects/:projectId/columns/:columnId/tickets/:ticketId", ticket.editTicket);
 
-  server.listen(5030, (err, address) => {
-    if (err) {
-      console.error(err);
-
-      process.exit(1);
-    }
-
-    console.log(`Server listening at ${address}`);
-  });
-
   return server;
 };
 

--- a/tests/helper/index.ts
+++ b/tests/helper/index.ts
@@ -27,6 +27,7 @@ export function build(): FastifyInstance {
   afterAll(async () => {
     await database.destroy();
     await app.close();
+    app.server.unref();
   });
 
   return app;


### PR DESCRIPTION
The cause of the error of just having too many child runners simultaneously was that all servers built upon test cases were listening on the same port. As fastify won't need to have a listener running on a test, I extracted the listener function and placed it in the app's init logic.